### PR TITLE
Allow Handlebars to be a global

### DIFF
--- a/hbs.js
+++ b/hbs.js
@@ -1,4 +1,5 @@
 define(["handlebars"], function(Handlebars) {
+  Handlebars = Handlebars || this.Handlebars;
   var buildMap = {},
       templateExtension = ".hbs";
 
@@ -35,7 +36,7 @@ define(["handlebars"], function(Handlebars) {
       // definition.
       write(
         "define('hbs!" + name + "', ['handlebars'], function(Handlebars){ \n" +
-          "Handlebars = Handlebars || window.Handlebars;\n" +
+          "Handlebars = Handlebars || this.Handlebars;\n" +
           "return Handlebars.template(" + compiled.toString() + ");\n" +
         "});\n"
       );


### PR DESCRIPTION
If Handlebars is included in optimizer, the shim don't work. Always have a fallback to window.
