### PR TITLE
Better FS path generation

### DIFF
--- a/hbs.js
+++ b/hbs.js
@@ -14,7 +14,7 @@ define(["handlebars"], function(Handlebars) {
         // Use node.js file system module to load the template.
         // Sorry, no Rhino support.
         var fs = nodeRequire("fs");
-        var fsPath = config.dirBaseUrl + "/" + name + ext;
+        var fsPath = require.toUrl(name + ext);
         buildMap[name] = fs.readFileSync(fsPath).toString();
         onload();
       } else {


### PR DESCRIPTION
I can't build my app, because of wrong path of `hbs!` template.

See error log:

``` bash
$ r.js -o build.js

Tracing dependencies for: app
Error: ENOENT, no such file or directory '(...)\public\js\lib\templates\app\client\orders\modal\comments.html'
In module tree:
    app/client/orders/index
      hbs

Error: Error: ENOENT, no such file or directory '(...)\public\js\lib\templates\app\client\orders\modal\comments.html'
In module tree:
    app/client/orders/index
      hbs

    at Object.fs.openSync (fs.js:427:18)
```

I have this file in `public/js/templates/app/client/orders/modal/comments.html`. In app.js:

``` js
require.config({
    'baseUrl': require.toUrl('lib'),
    'paths': {
        'app': '../app',
        'templates': '../templates'
    }
}
```

But after my little patch should work.
