### PR TITLE
fix resolving path in node build

### DIFF
--- a/hbs.js
+++ b/hbs.js
@@ -14,7 +14,7 @@ define(["handlebars"], function(Handlebars) {
         // Use node.js file system module to load the template.
         // Sorry, no Rhino support.
         var fs = nodeRequire("fs");
-        var fsPath = config.dirBaseUrl + "/" + name + ext;
+        var fsPath = parentRequire.toUrl(name + ext);
         buildMap[name] = fs.readFileSync(fsPath).toString();
         onload();
       } else {


### PR DESCRIPTION
using parentRequire will resolve custom paths and mappings propperly
